### PR TITLE
Resolve Deprecated alert in routing

### DIFF
--- a/lib/KCFinderBundle/Resources/config/routing.yml
+++ b/lib/KCFinderBundle/Resources/config/routing.yml
@@ -1,19 +1,19 @@
 KCFinder_browse:
-    pattern:  /kcfinder/browse.php
+    path:  /kcfinder/browse.php
     defaults: { _controller: "libKCFinderBundle:Proxy:browse" }
 
 KCFinder_css:
-    pattern:  /kcfinder/css.php
+    path:  /kcfinder/css.php
     defaults: { _controller: "libKCFinderBundle:Proxy:css" }
 
 KCFinder_js_localize:
-    pattern:  /kcfinder/js_localize.php
+    path:  /kcfinder/js_localize.php
     defaults: { _controller: "libKCFinderBundle:Proxy:js_localize" }
 
 KCFinder_upload:
-    pattern:  /kcfinder/upload.php
+    path:  /kcfinder/upload.php
     defaults: { _controller: "libKCFinderBundle:Proxy:upload" }
 
 KCFinder_js_browser_joiner:
-    pattern:  /kcfinder/js/browser/joiner.php
+    path:  /kcfinder/js/browser/joiner.php
     defaults: { _controller: "libKCFinderBundle:Proxy:js_browser_joiner" }


### PR DESCRIPTION
Message in Symfony 2.7 :
DEPRECATED - The "pattern" option in file "vendor\jocelynkerbourch\kc-finder-bundle\lib\KCFinderBundle/Resources/config/routing.yml" is deprecated since version 2.2 and will be removed in 3.0. Use the "path" option in the route definition instead.
